### PR TITLE
Fix graphical glitches caused by indexing errors

### DIFF
--- a/huc6270.vhd
+++ b/huc6270.vhd
@@ -1675,6 +1675,7 @@ begin
 				DMA_RAM_REQ_FF <= not DMA_RAM_REQ_FF;
 				DMA_RAM_A_FF <= DESR;
 				DMA_RAM_WE_FF <= '1';
+				DMA <= DMA_WRITE1;
 
 			when DMA_WRITE1 =>
 				if CLKEN = '1' and DMA_RAM_REQ_FF = DMA_RAM_ACK then


### PR DESCRIPTION
Use Previous X value when rendering.
-Fixes last vertical line in display area.
-e.g. Bomberman 94
Add one to Sprite Y value when reading Sprite Attribute Table.  SAT is read one line before rendering and must be offset by one to line up correctly.
-Fixes sprite glitches
-e.g. Bomberman 94 intro where last line would show up above where intended.
Reset Sprite buffers when sprites are disabled.
-Prevents the last line of sprites from the last time sprites were enabled from showing up in the display line immediately after sprites are enabled.
-e.g. Neutopia intro and vertical scrolling in game.