### PR TITLE
Fix horizontal sync width

### DIFF
--- a/huc6260.vhd
+++ b/huc6260.vhd
@@ -10,6 +10,8 @@ entity huc6260 is
 	port (
 		CLK 		: in std_logic;
 		RESET_N	: in std_logic;
+		--For convenience
+		DOTCLOCK_O : out std_logic_vector(1 downto 0);
 
 		-- CPU Interface
 		A			: in std_logic_vector(2 downto 0);
@@ -273,5 +275,6 @@ begin
 	end if;
 end process;
 
+DOTCLOCK_O <= DOTCLOCK;
 
 end rtl;

--- a/pce_top.vhd
+++ b/pce_top.vhd
@@ -87,6 +87,7 @@ signal RAM_DO			: std_logic_vector(7 downto 0);
 
 -- VCE signals
 signal VCE_DO			: std_logic_vector(7 downto 0);
+signal DOTCLOCK		: std_logic_vector(1 downto 0);
 
 -- VDC signals
 signal VDC_DO			: std_logic_vector(7 downto 0);
@@ -221,6 +222,7 @@ VIDEO_HS_N <= HS_N;
 VCE : entity work.huc6260 port map(
 	CLK 		=> CLK,
 	RESET_N		=> RESET_N,
+	DOTCLOCK_O => DOTCLOCK,
 
 	-- CPU Interface
 	A			=> CPU_A(2 downto 0),
@@ -248,6 +250,7 @@ VCE : entity work.huc6260 port map(
 VDC : entity work.huc6270 port map(
 	CLK 		=> CLK,
 	RESET_N		=> RESET_N,
+	DOTCLOCK => DOTCLOCK,
 
 	-- CPU Interface
 	A			=> CPU_A(1 downto 0),


### PR DESCRIPTION
Current implmentation only supports external hsync (generated in the huc6260, not the huc6270).  This means that HSW register is ignored and the constant sync width of the huc6260 generated signal is used.
--Fixes games that aren't centered properly.
--Uncertain of the behavior for different dotclocks (are all dotclocks 3*8 clock cycles, or do they vary?)  Needs testing.