### PR TITLE
Set Timer Interrupt on underflow; Fix VSW values less than 2

### DIFF
--- a/huc6270.vhd
+++ b/huc6270.vhd
@@ -631,7 +631,7 @@ begin
 						VBLANK_DONE <= '0';
 						
 						V_VDS := VSR(15 downto 8);
-						V_VSW := VSR(4 downto 0) - 2;
+						V_VSW := VSR(4 downto 0);
 						V_VDW := VDR(8 downto 0);
 						V_VCR := VDE(7 downto 0);
 						
@@ -641,31 +641,37 @@ begin
 						VCR <= V_VCR;
 
 						Y_DISP_START <= ("0000" & V_VSW)
-							+ ("0" & V_VDS);
+							+ ("0" & V_VDS)
+							- 2;
 						
 						Y_BGREN_START <= ("0000" & V_VSW)
 							+ ("0" & V_VDS)
-							+ ( "000000010" );
+							+ ( "000000010" )
+							- 2;
 						
 						Y_BGREN_END <= ("0000" & V_VSW)
 							+ ("0" & V_VDS)
 							+ V_VDW
-							+ ( "000000011" );							
+							+ ( "000000011" )
+							- 2;							
 							
 						Y_SP_START <= ("0000" & V_VSW)
 							+ ("0" & V_VDS)
-							+ ( "000000001" );
+							+ ( "000000001" )
+							- 2;
 						
 						Y_SP_END <= ("0000" & V_VSW)
 							+ ("0" & V_VDS)
 							+ V_VDW
-							+ ( "000000010" );
+							+ ( "000000010" )
+							- 2;
 			
 						Y_DISP_END <= ("0000" & V_VSW)
 							+ ("0" & V_VDS)
 							+ V_VDW
 							+ ("0" & V_VCR)
-							+ ( "000000011" );
+							+ ( "000000011" )
+							- 2;
 
 						-- Is it needed ?
 						if CR(7 downto 6) = "00" then

--- a/huc6280.vhd
+++ b/huc6280.vhd
@@ -462,11 +462,11 @@ begin
 		if RESET_N = '0' then
 			TMR_VALUE <= (others => '0');
 		elsif TMR_RELOAD = '1' then
-			TMR_VALUE <= TMR_LATCH & "1111111111";
+			TMR_VALUE <= TMR_LATCH & "1111111110";
 		elsif TMR_CLKEN = '1' and TMR_EN = '1' then
 			TMR_VALUE <= TMR_VALUE - 1;
-			if TMR_VALUE = "0000000" & "0000000000" then
-				TMR_VALUE <= TMR_LATCH & "1111111111";
+			if TMR_VALUE = "1111111" & "1111111111" then
+				TMR_VALUE <= TMR_LATCH & "1111111110";
 				TMR_IRQ_REQ <= '1';
 			end if;
 		end if;


### PR DESCRIPTION
The timer interrupt is supposed to fire on underflow (transition from 0 to 1FFFF, not 0 to 1).  I think I did the math correctly for 1024 cycles per decrement.
--Fixes Battle Royal.
Adjust calculations for VSW.  Fixes values less than 2.
--Fixes Battle Royal starting vertical position.