### PR TITLE
Ack Timer interrupt when reading Interrupt mask

### DIFF
--- a/huc6280.vhd
+++ b/huc6280.vhd
@@ -286,6 +286,7 @@ begin
 						when "10" =>
 							DATA_BUF <= DATA_BUF(7 downto 3) & INT_MASK;
 							INT_DO <= DATA_BUF(7 downto 3) & INT_MASK;
+							TMR_IRQ_ACK <= '1';
 						when "11" =>
 							DATA_BUF <= DATA_BUF(7 downto 3) & TMR_IRQ & not( IRQ1_N ) & not( IRQ2_N );
 							INT_DO <= DATA_BUF(7 downto 3) & TMR_IRQ & not( IRQ1_N ) & not( IRQ2_N );


### PR DESCRIPTION
The Timer interrupt is cleared when reading the interrupt mask.
--Makes After Burner 2 playable for a while before crashing.