### PR TITLE
Fix RTI Stack Pointer Range Error

### DIFF
--- a/cpu65xx.vhd
+++ b/cpu65xx.vhd
@@ -2329,6 +2329,9 @@ calcNextAddr: process(theCpuCycle, opcInfo, indexOut, U, reset, T) --GE added T
 				-- Replace with nextAddrIncr if emulating 65C02 or later cpu.
 				--GE nextAddr <= nextAddrIncrL; 
 				nextAddr <= nextAddrIncr; --GE
+				if opcInfo(opcRti) = '1' then
+					nextAddr <= nextAddrStack; --GE
+				end if;
 			--GE HuC6280 - no penalty for page crossing
 			--GE elsif indexOut(8) = '1' then 
 			--GE	nextAddr <= nextAddrIncrH;


### PR DESCRIPTION
RTI was using nextAddrIncr for one of the pop phases.  This can cause accesses that should be 0x21ff, 0x2100 to actually use 0x21ff, 0x2200.
--Fixes Coryoon and Puzzle Boy crashes.