### PR TITLE
Fix overlapping bits in TG16 sav file menu functions

### DIFF
--- a/TurboGrafx16.sv
+++ b/TurboGrafx16.sv
@@ -134,11 +134,11 @@ parameter CONF_STR2 = {
 };
 
 parameter CONF_STR3 = {
-	"6,Load state;"
+	"G,Load Backup RAM;"
 };
 
 parameter CONF_STR4 = {
-	"7,Save state;"
+	"7,Save Backup RAM;"
 };
 
 parameter CONF_STR5 = {
@@ -152,7 +152,7 @@ parameter CONF_STR5 = {
 	"OB,Sprites per line,Std(16),All(64);",
 `endif
 	"-;",
-	"OF,ROM Storage,DDR3,SDRAM;",
+	"O6,ROM Storage,DDR3,SDRAM;",
 	"O2,Turbo Tap,Disabled,Enabled;",
 	"O4,Controller Buttons,2,6;",
 	"R0,Reset;",
@@ -247,7 +247,7 @@ wire reset = (RESET | status[0] | buttons[1] | bk_loading);
 wire ce_rom;
 
 reg use_sdr = 0;
-always @(posedge clk_ram) if(rom_rd) use_sdr <= status[15];
+always @(posedge clk_ram) if(rom_rd) use_sdr <= status[6];
 
 pce_top #(MAX_SPPL) pce_top
 (
@@ -486,7 +486,7 @@ always @(posedge clk_sys) begin
 	if(downloading && img_mounted && img_size && !img_readonly) bk_ena <= 1;
 end
 
-wire bk_load    = status[6];
+wire bk_load    = status[16];
 wire bk_save    = status[7];
 reg  bk_loading = 0;
 reg  bk_state   = 0;

--- a/TurboGrafx16.sv
+++ b/TurboGrafx16.sv
@@ -130,7 +130,7 @@ parameter CONF_STR1 = {
 };
 
 parameter CONF_STR2 = {
-	"AB,Save Slot,1,2,3,4;"
+	"DE,Save Slot,1,2,3,4;"
 };
 
 parameter CONF_STR3 = {
@@ -152,7 +152,7 @@ parameter CONF_STR5 = {
 	"OB,Sprites per line,Std(16),All(64);",
 `endif
 	"-;",
-	"O6,ROM Storage,DDR3,SDRAM;",
+	"OF,ROM Storage,DDR3,SDRAM;",
 	"O2,Turbo Tap,Disabled,Enabled;",
 	"O4,Controller Buttons,2,6;",
 	"R0,Reset;",
@@ -247,7 +247,7 @@ wire reset = (RESET | status[0] | buttons[1] | bk_loading);
 wire ce_rom;
 
 reg use_sdr = 0;
-always @(posedge clk_ram) if(rom_rd) use_sdr <= status[6];
+always @(posedge clk_ram) if(rom_rd) use_sdr <= status[15];
 
 pce_top #(MAX_SPPL) pce_top
 (
@@ -505,7 +505,7 @@ always @(posedge clk_sys) begin
 		if(bk_ena & ((~old_load & bk_load) | (~old_save & bk_save))) begin
 			bk_state <= 1;
 			bk_loading <= bk_load;
-			sd_lba <= {status[11:10],4'd0};
+			sd_lba <= {status[14:13],4'd0};
 			sd_rd <=  bk_load;
 			sd_wr <= ~bk_load;
 		end

--- a/TurboGrafx16.sv
+++ b/TurboGrafx16.sv
@@ -124,8 +124,8 @@ wire [1:0] scale = status[9:8];
 parameter CONF_STR1 = {
 	"TGFX16;;",
 	"-;",
-	"FS,PCEBIN,Load TurboGrafx;",
-	"FS,SGX,Load SuperGrafx;",
+	"FS13,PCEBIN,Load TurboGrafx;",
+	"FS13,SGX,Load SuperGrafx;",
 	"-;"
 };
 


### PR DESCRIPTION
The power of two number is for the core to communicate its desired .sav size to main_mister. It doesn't bother the existing main, and would be used for a main_mister change I would like to submit soon.