### PR TITLE
Adjust aspect ratio

### DIFF
--- a/TurboGrafx16.sv
+++ b/TurboGrafx16.sv
@@ -144,8 +144,8 @@ assign LED_DISK  = 0;
 assign LED_POWER = 0;
 assign BUTTONS   = osd_btn;
 
-assign VIDEO_ARX = status[1] ? 8'd16 : 8'd4;
-assign VIDEO_ARY = status[1] ? 8'd9  : 8'd3; 
+assign VIDEO_ARX = status[1] ? 8'd16 : overscan ? 8'd53 : 8'd47;
+assign VIDEO_ARY = status[1] ? 8'd9  : overscan ? 8'd40 : 8'd37;
 
 `include "build_id.v" 
 parameter CONF_STR = {
@@ -163,7 +163,7 @@ parameter CONF_STR = {
 	"-;",
 	"O1,Aspect ratio,4:3,16:9;",
 	"O8A,Scandoubler Fx,None,HQ2x,CRT 25%,CRT 50%,CRT 75%;",
-	"OH,Vertical blank,Normal,Reduced;",
+	"OH,Overscan,On,Off;",
 `ifdef USE_SP64
 	"OB,Sprites per line,Std(16),All(64);",
 `endif
@@ -283,6 +283,8 @@ wire ce_rom;
 reg use_sdr = 0;
 always @(posedge clk_ram) if(rom_rd) use_sdr <= |sdram_sz[14:0]; //status[6];
 
+wire overscan = ~status[17];
+
 pce_top #(MAX_SPPL) pce_top
 (
 	.RESET(reset|cart_download),
@@ -321,7 +323,7 @@ pce_top #(MAX_SPPL) pce_top
 	.JOY4(~{joystick_3[11:4], joystick_3[1], joystick_3[2], joystick_3[0], joystick_3[3]}),
 	.JOY5(~{joystick_4[11:4], joystick_4[1], joystick_4[2], joystick_4[0], joystick_4[3]}),
 
-	.ReducedVBL(status[17]),
+	.ReducedVBL(~overscan),
 	.VIDEO_R(r),
 	.VIDEO_G(g),
 	.VIDEO_B(b),


### PR DESCRIPTION
This corrects the circles in the 240p test suite Linearity test.

Version 1.10 and lower of the 240p test suite have an incorrect
linearity pattern for 320 pixels width. It will be updated with a
new pattern in the future.

Also renamed the Vertical blank option to Overscan.