### PR TITLE
Fix for SuperGrafx default palette

### DIFF
--- a/rtl/cd/cd.vhd
+++ b/rtl/cd/cd.vhd
@@ -480,31 +480,23 @@ begin
 				when x"0F" =>
 					EXT_DO <= "0000" & ADPCM_FADER & "0";
 					
+				when x"C0" =>
+					EXT_DO <= x"00";
 				when x"C1" =>
 					EXT_DO <= x"AA";
 				when x"C2" =>
 					EXT_DO <= x"55";
 				when x"C3" =>
-					EXT_DO <= x"00";
+					EXT_DO <= x"03";
 
+				when x"C4" =>
+					EXT_DO <= x"FF";
 				when x"C5" =>
-					if CD_REGION = '1' then
-						EXT_DO <= x"55";
-					else
-						EXT_DO <= x"AA";
-					end if;
+					EXT_DO <= x"FF";
 				when x"C6" =>
-					if CD_REGION = '1' then
-						EXT_DO <= x"AA";
-					else
-						EXT_DO <= x"55";
-					end if;
+					EXT_DO <= x"FF";
 				when x"C7" =>
-					if CD_REGION = '1' then
-						EXT_DO <= x"C0";
-					else
-						EXT_DO <= x"03";
-					end if;
+					EXT_DO <= x"FF";
 				when others => null;
 			end case;
 		end if;

--- a/rtl/cd/cd.vhd
+++ b/rtl/cd/cd.vhd
@@ -480,23 +480,31 @@ begin
 				when x"0F" =>
 					EXT_DO <= "0000" & ADPCM_FADER & "0";
 					
-				when x"C0" =>
-					EXT_DO <= x"00";
 				when x"C1" =>
 					EXT_DO <= x"AA";
 				when x"C2" =>
 					EXT_DO <= x"55";
 				when x"C3" =>
-					EXT_DO <= x"03";
+					EXT_DO <= x"00";
 
-				when x"C4" =>
-					EXT_DO <= x"FF";
 				when x"C5" =>
-					EXT_DO <= x"FF";
+					if CD_REGION = '1' then
+						EXT_DO <= x"55";
+					else
+						EXT_DO <= x"AA";
+					end if;
 				when x"C6" =>
-					EXT_DO <= x"FF";
+					if CD_REGION = '1' then
+						EXT_DO <= x"AA";
+					else
+						EXT_DO <= x"55";
+					end if;
 				when x"C7" =>
-					EXT_DO <= x"FF";
+					if CD_REGION = '1' then
+						EXT_DO <= x"C0";
+					else
+						EXT_DO <= x"03";
+					end if;
 				when others => null;
 			end case;
 		end if;

--- a/rtl/huc6202.vhd
+++ b/rtl/huc6202.vhd
@@ -38,6 +38,8 @@ entity huc6202 is
 		VDC1_IN	: in std_logic_vector(8 downto 0);
 		VDC_OUT	: out std_logic_vector(8 downto 0);
 
+		SGX		: in std_logic;
+
 		VDCNUM	: out std_logic
 	);
 end huc6202;
@@ -100,7 +102,11 @@ begin
 
 			if INMIX = '1' and PRI(1 downto 0) /= "00" and VDCDATA(7 downto 0) = x"00" then
 				-- replace color 0 -> 256 if in mixing and one of VDC is enabled
-				VDC_OUT <= "100000000";
+				if SGX = '1' then
+					VDC_OUT <= "000000000";
+				else
+					VDC_OUT <= "100000000";
+				end if;
 			else
 				VDC_OUT <= VDCDATA;
 			end if;

--- a/rtl/pce_top.vhd
+++ b/rtl/pce_top.vhd
@@ -470,6 +470,8 @@ generate_SGX: if (LITE = 0) generate begin
 		VDC0_IN  => VDC0_COLNO,
 		VDC1_IN  => VDC1_COLNO,
 		VDC_OUT  => VDC_COLNO,
+		
+		SGX		=> SGX,
 
 		VDCNUM   => VDCNUM
 	);


### PR DESCRIPTION
Default palette for regular PCE = Sprite number 0 palette; however, SuperGrafx default color (when neither VDC shows) is background number 0.
Space Ava 201's SuperGrafx mode title screen showed this issue.