### PR TITLE
Modify scanlines per field, based on artifact bit

### DIFF
--- a/TurboGrafx16.sv
+++ b/TurboGrafx16.sv
@@ -383,7 +383,7 @@ pce_top #(LITE) pce_top
 	.ROM_RDY(rom_sdrdy & rom_ddrdy & ram_ddrdy),
 	.ROM_A(rom_rdaddr),
 	.ROM_DO(use_sdr ? rom_sdata : rom_ddata),
-	.ROM_SZ(romwr_a[23:16]),
+	.ROM_SZ(romwr_a[23:12]),
 	.ROM_POP(populous[romwr_a[9]]),
 	.ROM_CLKEN(ce_rom),
 

--- a/rtl/huc6260.vhd
+++ b/rtl/huc6260.vhd
@@ -82,6 +82,7 @@ constant TOP_BL_LINES_E	: integer := 19;   -- pcetech.txt (must include VS_LINES
 constant DISP_LINES_E	: integer := 242;	 -- same as in mednafen
 signal TOP_BL_LINES		: integer;
 signal DISP_LINES			: integer;
+signal END_LINE			: integer := TOTAL_LINES;
 
 signal H_CNT	: std_logic_vector(11 downto 0);
 signal V_CNT	: std_logic_vector(9 downto 0);
@@ -215,8 +216,13 @@ begin
 			CLKEN_FF <= '1';				
 			H_CNT <= (others => '0');
 			V_CNT <= V_CNT + 1;
-			if V_CNT = TOTAL_LINES-1 then
+			if V_CNT >= END_LINE-1 then
 				V_CNT <= (others => '0');
+				if CR(2) = '1' then			-- artifact bit affects number of lines per field; check at start of field
+				  END_LINE <= TOTAL_LINES;
+				else
+				  END_LINE <= TOTAL_LINES - 1;
+				end if;
 			end if;
 			-- Reload registers
 			BW <= CR(7);
@@ -272,7 +278,7 @@ begin
 		VS_R <= '0';
 		if H_CNT = LINE_CLOCKS-1 then HS_F <= '1'; end if;
 		if H_CNT = HS_CLOCKS-1   then HS_R <= '1'; end if;
-		if V_CNT = TOTAL_LINES-1 and H_CNT = LINE_CLOCKS-1 then VS_F <= '1'; end if;
+		if V_CNT = END_LINE-1    and H_CNT = LINE_CLOCKS-1 then VS_F <= '1'; end if;
 		if V_CNT = VS_LINES-1    and H_CNT = LINE_CLOCKS-1 then VS_R <= '1'; end if;
 	end if;
 end process;

--- a/rtl/pce_top.vhd
+++ b/rtl/pce_top.vhd
@@ -17,7 +17,7 @@ entity pce_top is
 		ROM_RDY		: in  std_logic;
 		ROM_A 		: out std_logic_vector(21 downto 0);
 		ROM_DO 		: in  std_logic_vector(7 downto 0);
-		ROM_SZ 		: in  std_logic_vector(7 downto 0);
+		ROM_SZ 		: in  std_logic_vector(11 downto 0);
 		ROM_POP		: in  std_logic;
 		ROM_CLKEN	: out std_logic;
 
@@ -565,14 +565,14 @@ CPU_DI <= RAM_DO        when CPU_RAM_SEL_N  = '0'
 -- 512K ROM, mapped ABCDABCD -> simple repeat
 -- 1MB and others            -> Straight mapping
 
-ROM_A <=   "00000"&CPU_A(16 downto 0)                                       when rom_sz = X"02" -- 128K
-      else "0000"&CPU_A(17 downto 0)                                        when rom_sz = X"04" -- 256K
-      else "000"&CPU_A(19)&(CPU_A(17) and not CPU_A(19))&CPU_A(16 downto 0) when rom_sz = X"06" -- 384K
-      else "000"&CPU_A(18 downto 0)                                         when rom_sz = X"08" -- 512K
-      else "00" &CPU_A(19)&(CPU_A(18) and not CPU_A(19))&CPU_A(17 downto 0) when rom_sz = X"0C" -- 768K
+ROM_A <=   "00000"&CPU_A(16 downto 0)                                       when rom_sz = X"020" -- 128K
+      else "0000"&CPU_A(17 downto 0)                                        when rom_sz = X"040" -- 256K
+      else "000"&CPU_A(19)&(CPU_A(17) and not CPU_A(19))&CPU_A(16 downto 0) when rom_sz = X"060" -- 384K
+      else "000"&CPU_A(18 downto 0)                                         when rom_sz = X"080" -- 512K
+      else "00" &CPU_A(19)&(CPU_A(18) and not CPU_A(19))&CPU_A(17 downto 0) when rom_sz = X"0C0" -- 768K
       else (CPU_A(19) and (rombank(0) and rombank(1)))
           &(CPU_A(19) and (rombank(0) xor rombank(1)))
-          &(CPU_A(19) and not rombank(0))&CPU_A(18 downto 0)                when rom_sz = X"28" -- SF2
+          &(CPU_A(19) and not rombank(0))&CPU_A(18 downto 0)                when rom_sz = X"280" -- SF2
       else "00"&CPU_A(19 downto 0);                                                             -- 1MB and others
 
 ROM_RD    <= CPU_PRE_RD and not CPU_ROM_SEL_N and CPU_PRAM_SEL_N and ((AC_RAM_CS_N and CD_RAM_CS_N) or not CD_EN);


### PR DESCRIPTION
Bit 2 of $0400 will remove color artifacts (on the original machine), but it also changes the number of lines per field.
With the bit set (normal when displaying text), there are 263 lines per field; with the bit reset, there are only 262.
This fix corrects this situation, and makes the core act like the real machine.