### PR TITLE
Fix incorrect TIMER interrupt acknowledge condition - to fix issue #186

### DIFF
--- a/rtl/HUC6280/HUC6280.vhd
+++ b/rtl/HUC6280/HUC6280.vhd
@@ -223,12 +223,6 @@ begin
 							TMR_IRQ_ACK <= '1';
 						when others => null;
 					end case;
-				else
-					case CPU_A(1 downto 0) is
-						when "10" =>
-							TMR_IRQ_ACK <= '1';
-						when others => null;
-					end case;
 				end if; 
 			end if; 
 		end if;


### PR DESCRIPTION
TIMER interrupts are acknowledged by writes to $1403; this code was also acknowledging them when addressing $1402 in a "non-write" state (read, I guess, but possibly others).

Official documentation makes no mention of acknowledgement other than writes to $1403.  Removal of the $1402 acknowledgement seems to fix the issue.