### PR TITLE
Minor fix to BRAM locking (fixes issue #201 )

### DIFF
--- a/rtl/cd/cd.vhd
+++ b/rtl/cd/cd.vhd
@@ -247,9 +247,8 @@ begin
 							CH_SEL <= not CH_SEL;
 							
 						when x"07" =>
-							if EXT_DI(7) = '1' then
-								BRAM_LOCK <= '0';
-							end if;
+						   BRAM_LOCK <= not EXT_DI(7);  -- unlock when bit 7 is '1', but also lock if bit 7 is '0'
+
 						when x"08" =>
 							ADPCM_OFFS(7 downto 0) <= EXT_DI;
 						when x"09" =>


### PR DESCRIPTION
Writing a '1' to bit 7 (value $80) to CD status register at $1807 unlocks the Backup RAM - this is implemented correctly. However, writing a '0' to the same bit should lock the Backup RAM again (not implemented).