### PR TITLE
Adjust display line width for 7MHz mode #223

### DIFF
--- a/rtl/huc6270.vhd
+++ b/rtl/huc6270.vhd
@@ -348,8 +348,8 @@ begin
 
 	HSW_END_POS <= "00"&unsigned(HSW) + ("000000"&unsigned(RES7M));
 	HDS_END_POS <= ("00"&unsigned(HSW)) + ("000000"&unsigned(RES7M)) + 1 + unsigned(HDS);
-	HDISP_END_POS <= ("00"&unsigned(HSW)) + 1 + unsigned(HDS) + 1 + unsigned(HDW);
-	HDE_END_POS <= ("00"&unsigned(HSW)) + 1 + unsigned(HDS) + 1 + unsigned(HDW) + 1 + unsigned(HDE);
+	HDISP_END_POS <= ("00"&unsigned(HSW)) + 1 + unsigned(HDS) + 1 + unsigned(HDW) + ("000000"&unsigned(RES7M));
+	HDE_END_POS <= ("00"&unsigned(HSW)) + 1 + unsigned(HDS) + 1 + unsigned(HDW) + 1 + unsigned(HDE) + ("000000"&unsigned(RES7M));
 	
 	VSW_END_POS <= ("00000"&unsigned(VSW));
 	VDS_END_POS <= ("00000"&unsigned(VSW)) + 1 + ("00"&unsigned(VDS)) + 1;


### PR DESCRIPTION
I believe this was needed after the recent VDC commit.
If this is not a correct change, please reject the Pull request.